### PR TITLE
Create UCSBDiningCommonsMenuItemController, add GET (index) and POST (create)

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 
 @Tag(name = "UCSBDiningCommonsMenuItems")
-@RequestMapping("/api/UCSBDiningCommonsMenuItem")
+@RequestMapping("/api/ucsbdiningcommonsmenuitems")
 @RestController
 @Slf4j
 public class UCSBDiningCommonsMenuItemController {

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -1,0 +1,59 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@Tag(name = "UCSBDiningCommonsMenuItems")
+@RequestMapping("/api/UCSBDiningCommonsMenuItem")
+@RestController
+@Slf4j
+public class UCSBDiningCommonsMenuItemController {
+    @Autowired
+    UCSBDiningCommonsMenuItemRepository ucsbDiningCommonsMenuItemRepository;
+
+    @Operation(summary= "List all ucsb dining common menu items")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<UCSBDiningCommonsMenuItem> allUCSBDiningCommonMenuItems() {
+        Iterable<UCSBDiningCommonsMenuItem> items = ucsbDiningCommonsMenuItemRepository.findAll();
+        return items;
+    }
+
+    @Operation(summary= "Create a new ucsb dining common menu item")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public UCSBDiningCommonsMenuItem postUCSBDiningCommonsMenuItem(
+            @Parameter(name="diningCommonsCode") @RequestParam String diningCommonsCode,
+            @Parameter(name="station") @RequestParam String station,
+            @Parameter(name="name") @RequestParam String name)
+            throws JsonProcessingException {
+
+        UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem = new UCSBDiningCommonsMenuItem();
+        ucsbDiningCommonsMenuItem.setDiningCommonsCode(diningCommonsCode);
+        ucsbDiningCommonsMenuItem.setStation(station);
+        ucsbDiningCommonsMenuItem.setName(name);
+
+        UCSBDiningCommonsMenuItem savedUcsbDiningCommonsMenuItem = ucsbDiningCommonsMenuItemRepository.save(ucsbDiningCommonsMenuItem);
+
+        return savedUcsbDiningCommonsMenuItem;
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
@@ -47,14 +47,14 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
 
         @Test
         public void logged_out_users_cannot_get_all() throws Exception {
-                mockMvc.perform(get("/api/UCSBDiningCommonsMenuItem/all"))
+                mockMvc.perform(get("/api/ucsbdiningcommonsmenuitems/all"))
                                 .andExpect(status().is(403)); // logged out users can't get all
         }
 
         @WithMockUser(roles = { "USER" })
         @Test
         public void logged_in_users_can_get_all() throws Exception {
-                mockMvc.perform(get("/api/UCSBDiningCommonsMenuItem/all"))
+                mockMvc.perform(get("/api/ucsbdiningcommonsmenuitems/all"))
                                 .andExpect(status().is(200)); // logged
         }
 
@@ -80,7 +80,7 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
                 when(ucsbDiningCommonsMenuItemRepository.findAll()).thenReturn(expectedItems);
 
                 // act
-                MvcResult response = mockMvc.perform(get("/api/UCSBDiningCommonsMenuItem/all"))
+                MvcResult response = mockMvc.perform(get("/api/ucsbdiningcommonsmenuitems/all"))
                                 .andExpect(status().isOk()).andReturn();
 
                 // assert
@@ -94,14 +94,14 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
         // Tests for POST /api/UCSBDiningCommonsMenuItem/post...
         @Test
         public void logged_out_users_cannot_post() throws Exception {
-                mockMvc.perform(post("/api/UCSBDiningCommonsMenuItem/post"))
+                mockMvc.perform(post("/api/ucsbdiningcommonsmenuitems/post"))
                                 .andExpect(status().is(403));
         }
 
         @WithMockUser(roles = { "USER" })
         @Test
         public void logged_in_regular_users_cannot_post() throws Exception {
-                mockMvc.perform(post("/api/UCSBDiningCommonsMenuItem/post"))
+                mockMvc.perform(post("/api/ucsbdiningcommonsmenuitems/post"))
                                 .andExpect(status().is(403)); // only admins can post
         }
 
@@ -120,7 +120,7 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                post("/api/UCSBDiningCommonsMenuItem/post?diningCommonsCode=DLG&station=Pizza&name=Cheese Pizza")
+                                post("/api/ucsbdiningcommonsmenuitems/post?diningCommonsCode=DLG&station=Pizza&name=Cheese Pizza")
                                                 .with(csrf()))
                                 .andExpect(status().isOk()).andReturn();
 

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
@@ -1,0 +1,133 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
+import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.time.LocalDateTime;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = UCSBDiningCommonsMenuItemController.class)
+@Import(TestConfig.class)
+public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase{
+        @MockBean
+        UCSBDiningCommonsMenuItemRepository ucsbDiningCommonsMenuItemRepository;
+
+        @MockBean
+        UserRepository userRepository;
+
+        // Tests for GET /api/UCSBDiningCommonsMenuItem/all
+
+        @Test
+        public void logged_out_users_cannot_get_all() throws Exception {
+                mockMvc.perform(get("/api/UCSBDiningCommonsMenuItem/all"))
+                                .andExpect(status().is(403)); // logged out users can't get all
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_can_get_all() throws Exception {
+                mockMvc.perform(get("/api/UCSBDiningCommonsMenuItem/all"))
+                                .andExpect(status().is(200)); // logged
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_user_can_get_all_ucsb_dining_commons_menu_items() throws Exception {
+
+                UCSBDiningCommonsMenuItem menuItem1 = UCSBDiningCommonsMenuItem.builder()
+                                .diningCommonsCode("DLG")
+                                .station("Pizza")
+                                .name("Cheese Pizza")
+                                .build();
+                
+                UCSBDiningCommonsMenuItem menuItem2 = UCSBDiningCommonsMenuItem.builder()
+                                .diningCommonsCode("DLG")
+                                .station("Pizza")
+                                .name("Pepperoni Pizza")
+                                .build();
+
+                ArrayList<UCSBDiningCommonsMenuItem> expectedItems = new ArrayList<>();
+                expectedItems.addAll(Arrays.asList(menuItem1, menuItem2));
+
+                when(ucsbDiningCommonsMenuItemRepository.findAll()).thenReturn(expectedItems);
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/UCSBDiningCommonsMenuItem/all"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(ucsbDiningCommonsMenuItemRepository, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(expectedItems);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        // Tests for POST /api/UCSBDiningCommonsMenuItem/post...
+        @Test
+        public void logged_out_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/UCSBDiningCommonsMenuItem/post"))
+                                .andExpect(status().is(403));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_regular_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/UCSBDiningCommonsMenuItem/post"))
+                                .andExpect(status().is(403)); // only admins can post
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void an_admin_user_can_post_a_new_ucsb_dining_commons_menu_item() throws Exception {
+                // arrange
+
+                UCSBDiningCommonsMenuItem menuItem1 = UCSBDiningCommonsMenuItem.builder()
+                                .diningCommonsCode("DLG")
+                                .station("Pizza")
+                                .name("Cheese Pizza")
+                                .build();
+
+                when(ucsbDiningCommonsMenuItemRepository.save(eq(menuItem1))).thenReturn(menuItem1);
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                post("/api/UCSBDiningCommonsMenuItem/post?diningCommonsCode=DLG&station=Pizza&name=Cheese Pizza")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(ucsbDiningCommonsMenuItemRepository, times(1)).save(menuItem1);
+                String expectedJson = mapper.writeValueAsString(menuItem1);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+}


### PR DESCRIPTION
Add GET and POST endpoints for UCSBDiningCommonsMenuItemController, used to retrieve and add new menu items. Tested on: https://team02-ajs808-dev.dokku-04.cs.ucsb.edu/ (log in and use swagger)

Closes #9 