### PR TITLE
Add GET (show) endpoint for single record in RecommendationRequest Database Table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
@@ -76,5 +76,17 @@ public class RecommendationRequestController extends ApiController{
 
         return savedRecommendationRequest;
     }
+
+      @Operation(summary= "Get a single request")
+      @PreAuthorize("hasRole('ROLE_USER')")
+      @GetMapping("")
+      public RecommendationRequest getById(
+            @Parameter(name="id") @RequestParam Long id) {
+        RecommendationRequest recommendationRequest = recommendationRequestRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(RecommendationRequest.class, id));
+
+        return recommendationRequest;
+    }
+
 }
 

--- a/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
@@ -1,0 +1,80 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.RecommendationRequest;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.RecommendationRequestRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+import java.time.LocalDateTime;
+
+@Tag(name = "RecommendationRequest")
+@RequestMapping("/api/recommendationrequest")
+@RestController
+@Slf4j
+
+public class RecommendationRequestController {
+
+    @Autowired
+    RecommendationRequestRepository recommendationRequestRepository;
+
+    @Operation(summary= "List all recommendation requests")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<RecommendationRequest> allRecomendationRequest() {
+        Iterable<RecommendationRequest> requests = recommendationRequestRepository.findAll();
+        return requests;
+    }
+
+    @Operation(summary= "Create a new recommendation request")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public RecommendationRequest postRecommendationRequest(
+            @Parameter(name="requesterEmail") @RequestParam String requesterEmail,
+            @Parameter(name="professorEmail") @RequestParam String professorEmail,
+            @Parameter(name="explanation") @RequestParam String explanation,
+            @Parameter(name="dateRequested", description="in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601") @RequestParam("dateRequested") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime dateRequested,
+            @Parameter(name="dateNeeded", description="in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601") @RequestParam("dateNeeded") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime dateNeeded,
+            @Parameter(name="done") @RequestParam boolean done)
+            throws JsonProcessingException {
+
+        // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        // See: https://www.baeldung.com/spring-date-parameters
+
+        log.info("dateRequested={}", dateRequested);
+        log.info("dateNeeded={}", dateNeeded);
+
+        RecommendationRequest recommendationRequest = new RecommendationRequest();
+        recommendationRequest.setRequesterEmail(requesterEmail);
+        recommendationRequest.setProfessorEmail(professorEmail);
+        recommendationRequest.setExplanation(explanation);
+        recommendationRequest.setDateRequested(dateRequested);
+        recommendationRequest.setDateNeeded(dateNeeded);
+        recommendationRequest.setDone(done);
+
+
+        RecommendationRequest savedRecommendationRequest = recommendationRequestRepository.save(recommendationRequest);
+
+        return savedRecommendationRequest;
+    }
+}
+

--- a/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
@@ -32,7 +32,7 @@ import java.time.LocalDateTime;
 @RestController
 @Slf4j
 
-public class RecommendationRequestController {
+public class RecommendationRequestController extends ApiController{
 
     @Autowired
     RecommendationRequestRepository recommendationRequestRepository;
@@ -40,7 +40,7 @@ public class RecommendationRequestController {
     @Operation(summary= "List all recommendation requests")
     @PreAuthorize("hasRole('ROLE_USER')")
     @GetMapping("/all")
-    public Iterable<RecommendationRequest> allRecomendationRequest() {
+    public Iterable<RecommendationRequest> allRecomendationRequests() {
         Iterable<RecommendationRequest> requests = recommendationRequestRepository.findAll();
         return requests;
     }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
@@ -44,7 +44,7 @@ public class RecommendationRequestControllerTests extends ControllerTestCase {
         @MockBean
         UserRepository userRepository;
 
-        // Tests for GET /api/ucsbdates/all
+        // Tests for GET /api/recommendationrequest/all
         
         @Test
         public void logged_out_users_cannot_get_all() throws Exception {
@@ -105,7 +105,7 @@ public class RecommendationRequestControllerTests extends ControllerTestCase {
                 assertEquals(expectedJson, responseString);
         }
 
-        // Tests for POST /api/ucsbdates/post...
+        // Tests for POST /api/recommendationrequest/post...
 
         @Test
         public void logged_out_users_cannot_post() throws Exception {
@@ -151,4 +151,67 @@ public class RecommendationRequestControllerTests extends ControllerTestCase {
                 String responseString = response.getResponse().getContentAsString();
                 assertEquals(expectedJson, responseString);
         }
+
+
+        // Tests for GET /api/recommendationrequest?id=...
+
+        @Test
+        public void logged_out_users_cannot_get_by_id() throws Exception {
+                mockMvc.perform(get("/api/recommendationrequest?id=7"))
+                                .andExpect(status().is(403)); // logged out users can't get by id
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+                // arrange
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+		LocalDateTime ldt2 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                RecommendationRequest request1 = RecommendationRequest.builder()
+                                .requesterEmail("requester@gmail.com")
+                                .professorEmail("professor@gmail.com")
+                                .explanation("grad school")
+                                .dateRequested(ldt1)
+                                .dateNeeded(ldt2)
+                                .done(true)
+                                .build();
+
+
+                when(recommendationRequestRepository.findById(eq(7L))).thenReturn(Optional.of(request1));
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/recommendationrequest?id=7"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(recommendationRequestRepository, times(1)).findById(eq(7L));
+                String expectedJson = mapper.writeValueAsString(request1);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+                // arrange
+
+                when(recommendationRequestRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/recommendationrequest?id=7"))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                verify(recommendationRequestRepository, times(1)).findById(eq(7L));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("RecommendationRequest with id 7 not found", json.get("message"));
+        }
+
+
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
@@ -65,11 +65,11 @@ public class RecommendationRequestControllerTests extends ControllerTestCase {
 
                 // arrange
                 LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
-                LocalDateTime ldt2 = LocalDateTime.parse("2022-01-03T00:00:00");
+                LocalDateTime ldt2 = LocalDateTime.parse("2022-02-03T00:00:00");
 
                 RecommendationRequest request1 = RecommendationRequest.builder()
-                                .requesterEmail("requester@gmail.com")
-                                .professorEmail("professor@gmail.com")
+                                .requesterEmail("person1@gmail.com")
+                                .professorEmail("person2@gmail.com")
                                 .explanation("grad school")
                                 .dateRequested(ldt1)
                                 .dateNeeded(ldt2)
@@ -77,7 +77,7 @@ public class RecommendationRequestControllerTests extends ControllerTestCase {
                                 .build();
 
                 LocalDateTime ldt3 = LocalDateTime.parse("2022-03-11T00:00:00");
-                LocalDateTime ldt4 = LocalDateTime.parse("2022-03-11T00:00:00");
+                LocalDateTime ldt4 = LocalDateTime.parse("2022-04-11T00:00:00");
 
                 RecommendationRequest request2 = RecommendationRequest.builder()
                                 .requesterEmail("requester2@gmail.com")
@@ -126,7 +126,7 @@ public class RecommendationRequestControllerTests extends ControllerTestCase {
                 // arrange
 
                 LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
-                LocalDateTime ldt2 = LocalDateTime.parse("2022-01-03T00:00:00");
+                LocalDateTime ldt2 = LocalDateTime.parse("2022-02-03T00:00:00");
 
                 RecommendationRequest request1 = RecommendationRequest.builder()
                                 .requesterEmail("requester@gmail.com")
@@ -134,14 +134,14 @@ public class RecommendationRequestControllerTests extends ControllerTestCase {
                                 .explanation("grad school")
                                 .dateRequested(ldt1)
                                 .dateNeeded(ldt2)
-                                .done(false)
+                                .done(true)
                                 .build();
 
                 when(recommendationRequestRepository.save(eq(request1))).thenReturn(request1);
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                post("/api/recommendationrequest/post?requesterEmail=requester@gmail.com&professorEmail=professor@gmail.com&explanation=grad school&dateRequested=2022-01-03T00:00:00&dateNeeded=2022-01-03T00:00:00&done=false")
+                                post("/api/recommendationrequest/post?requesterEmail=requester@gmail.com&professorEmail=professor@gmail.com&explanation=grad school&dateRequested=2022-01-03T00:00:00&dateNeeded=2022-02-03T00:00:00&done=true")
                                                 .with(csrf()))
                                 .andExpect(status().isOk()).andReturn();
 

--- a/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
@@ -1,0 +1,154 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.RecommendationRequest;
+import edu.ucsb.cs156.example.repositories.RecommendationRequestRepository;
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.time.LocalDateTime;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = RecommendationRequestController.class)
+@Import(TestConfig.class)
+public class RecommendationRequestControllerTests extends ControllerTestCase {
+
+        @MockBean
+        RecommendationRequestRepository recommendationRequestRepository;
+
+        @MockBean
+        UserRepository userRepository;
+
+        // Tests for GET /api/ucsbdates/all
+        
+        @Test
+        public void logged_out_users_cannot_get_all() throws Exception {
+                mockMvc.perform(get("/api/recommendationrequest/all"))
+                                .andExpect(status().is(403)); // logged out users can't get all
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_can_get_all() throws Exception {
+                mockMvc.perform(get("/api/recommendationrequest/all"))
+                                .andExpect(status().is(200)); // logged
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_user_can_get_all_recommendation_request() throws Exception {
+
+                // arrange
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+                LocalDateTime ldt2 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                RecommendationRequest request1 = RecommendationRequest.builder()
+                                .requesterEmail("requester@gmail.com")
+                                .professorEmail("professor@gmail.com")
+                                .explanation("grad school")
+                                .dateRequested(ldt1)
+                                .dateNeeded(ldt2)
+                                .done(false)
+                                .build();
+
+                LocalDateTime ldt3 = LocalDateTime.parse("2022-03-11T00:00:00");
+                LocalDateTime ldt4 = LocalDateTime.parse("2022-03-11T00:00:00");
+
+                RecommendationRequest request2 = RecommendationRequest.builder()
+                                .requesterEmail("requester2@gmail.com")
+                                .professorEmail("professor2@gmail.com")
+                                .explanation("college")
+                                .dateRequested(ldt3)
+                                .dateNeeded(ldt4)
+                                .done(true)
+                                .build();
+
+                ArrayList<RecommendationRequest> expectedRequests = new ArrayList<>();
+                expectedRequests.addAll(Arrays.asList(request1, request2));
+
+                when(recommendationRequestRepository.findAll()).thenReturn(expectedRequests);
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/recommendationrequest/all"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(recommendationRequestRepository, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(expectedRequests);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        // Tests for POST /api/ucsbdates/post...
+
+        @Test
+        public void logged_out_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/recommendationrequest/post"))
+                                .andExpect(status().is(403));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_regular_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/recommendationrequest/post"))
+                                .andExpect(status().is(403)); // only admins can post
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void an_admin_user_can_post_a_new_recommendation_request() throws Exception {
+                // arrange
+
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+                LocalDateTime ldt2 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                RecommendationRequest request1 = RecommendationRequest.builder()
+                                .requesterEmail("requester@gmail.com")
+                                .professorEmail("professor@gmail.com")
+                                .explanation("grad school")
+                                .dateRequested(ldt1)
+                                .dateNeeded(ldt2)
+                                .done(false)
+                                .build();
+
+                when(recommendationRequestRepository.save(eq(request1))).thenReturn(request1);
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                post("/api/recommendationrequest/post?requesterEmail=requester@gmail.com&professorEmail=professor@gmail.com&explanation=grad school&dateRequested=2022-01-03T00:00:00&dateNeeded=2022-01-03T00:00:00&done=false")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(recommendationRequestRepository, times(1)).save(request1);
+                String expectedJson = mapper.writeValueAsString(request1);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+}


### PR DESCRIPTION
Closes #22 
Add the GET (show) endpoint for a single record of recommendation request in the RecommendationRequest Database table. Using admin and swagger, this has been tested at the following link:  https://team02-aditiphatak-dev.dokku-04.cs.ucsb.edu. 